### PR TITLE
prevent assigning empty for="" attributes to <label>s

### DIFF
--- a/src/cdh/core/templates/cdh.core/form_template.html
+++ b/src/cdh/core/templates/cdh.core/form_template.html
@@ -15,7 +15,7 @@
                 {% endwith %}
             >
                 <div class="uu-form-field">
-                    <label for="{{ field.id_for_label }}" class="form-label d-block">
+                    <label {% if field.id_for_label %}for="{{ field.id_for_label }}"{% endif %} class="form-label d-block">
                         {{ field.label }}
                     </label>
                     {{ field }}


### PR DESCRIPTION
This is a fix for an extremely minor but annoying bug encountered in Firefox.

Some form fields, like a radio button selection field, do not have a singular element with an id that can be used in a `for=""` attribute for the field's `<label>`. The current template code defaults to an empty `for=""`.

Quite harmless, except for the fact that Firefox will log a cryptic `Empty string passed to getElementById()` warning every time you hover over the label.