### PR TITLE
Fix Django 5.1 compatibility issue in `cdh.files`

### DIFF
--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -16,8 +16,6 @@ bpython==0.25
     # via cdh-django-core
 build==1.2.2.post1
     # via pip-tools
-cdh-django-core[all,core,dev,docs,federated-auth,files,mail,recommended,rest,vue] @ file:///home/michael/cdh/Grant%20Tool/saml-deploy/grant/src/cdh-django-core
-    # via file:///home/michael/cdh/grant%20tool/saml-deploy/grant/src/cdh-django-core
 certifi==2025.1.31
     # via requests
 cffi==1.17.1

--- a/src/cdh/files/db/fields.py
+++ b/src/cdh/files/db/fields.py
@@ -726,7 +726,7 @@ class TrackedFileField(ManyToManyField):
         return name, path, args, kwargs
 
     def contribute_to_class(self, cls, name, **kwargs):
-        if self.remote_field.is_hidden():
+        if self.remote_field.hidden:
             # If the backwards relation is disabled, replace the original
             # related_name with one generated from the m2m field name. Django
             # still uses backwards relations internally and we need to avoid


### PR DESCRIPTION
This PR fixes the `AttributeError: 'TrackedFileRel' object has no attribute 'is_hidden'. Did you mean: 'hidden'?`  error with Django 5.1.

As you can see, it's a fairly simple fix (even the one the stacktrace suggests!). However, to be sure I did check out if this is actually the _correct_ fix. The breaking change was done in this commit: https://github.com/django/django/commit/f65f8ab84ebd2fc9772d23a159e6178e1335bd8b; as you can see, `is_hidden()` was basically merged into the `hidden` attribute. 

I've also checked backwards compatibility with Django < 5.1; it's at least compatible down to 4.0: https://github.com/django/django/blob/ef62a3a68c9d558486145a42c0d71ea9a76add9e/django/db/models/fields/reverse_related.py#L65 (Which isn't even supported by DSC, but well)

I tried looking up that ref.id in the Django tracker, but I have yet to find it. So, not really sure why this was done. 



Aaalso, as an aside; I fixed a small issue in `requirements.txt`; it included a hardcoded absolute path to your project root. This is just an annoying thing with the dev project; you need the path-based dependency in the `.in` to get the proper dependency tree, but then you need to manually remove the entry in the compiled `.txt`. 

Honestly, it's a pain and if I would write this today I'd use someting like poetry to accomplish this. However, I'll leave that headache to you to solve, as it's fairly user-preference :)