### PR TITLE
Avoid deprecated escaping for Python 3.12

### DIFF
--- a/src/cdh/core/templatetags/datatables.py
+++ b/src/cdh/core/templatetags/datatables.py
@@ -13,7 +13,7 @@ class TranslateInfoNode(Node):
         if get_language() == 'nl':
             link = 'cdh.core/js/datatables/lang/dutch.json'
 
-        link = '{ &quot;url&quot;: &quot;%s&quot; }' % static(link).replace('/', '\/')
+        link = '{ &quot;url&quot;: &quot;%s&quot; }' % static(link).replace('/', r'\/')
 
         return mark_safe(link)
 


### PR DESCRIPTION
This fixes a DeprecationWarning when running/testing the project on Python 3.12. I haven't updated the readme because we aren't running tests for 3.12 yet. But I guess we could.

https://docs.python.org/3/whatsnew/3.6.html#deprecated-python-behavior