### PR TITLE
Avoid logging error on every ApiError

### DIFF
--- a/src/cdh/rest/exceptions.py
+++ b/src/cdh/rest/exceptions.py
@@ -9,7 +9,6 @@ class ApiError(Exception):
         super(ApiError, self).__init__(*args)
         self.status_code = status_code
         self.message = message
-        logger.error(f"Status {status_code}: {message}")
 
 
     def __str__(self):


### PR DESCRIPTION
The current code will always log an error whenever an `ApiError` exception is thrown, because it's in the `__init__()` method of the exception.
However, it should be the responsibility of the call site to decide whether such an exception should be logged when it's caught. (if it's not caught, it will be logged anyway by default)

This issue has come up in the context of PPN: https://github.com/UiL-OTS-labs/ppn-backend/issues/165